### PR TITLE
Fix generateRelations field in model generator.

### DIFF
--- a/src/generators/model/form.php
+++ b/src/generators/model/form.php
@@ -1,7 +1,10 @@
 <?php
+
+use dlds\giixer\generators\model\Generator;
+
 /* @var $this yii\web\View */
 /* @var $form yii\widgets\ActiveForm */
-/* @var $generator yii\gii\generators\form\Generator */
+/* @var $generator dlds\giixer\generators\model\Generator */
 
 echo $form->field($generator, 'tableName');
 echo $form->field($generator, 'modelClass');
@@ -9,7 +12,11 @@ echo $form->field($generator, 'ns');
 echo $form->field($generator, 'baseClass');
 echo $form->field($generator, 'db');
 echo $form->field($generator, 'useTablePrefix')->checkbox();
-echo $form->field($generator, 'generateRelations')->checkbox();
+echo $form->field($generator, 'generateRelations')->dropDownList([
+    Generator::RELATIONS_NONE => 'No relations',
+    Generator::RELATIONS_ALL => 'All relations',
+    Generator::RELATIONS_ALL_INVERSE => 'All relations with inverse',
+]);
 echo $form->field($generator, 'generateLabelsFromComments')->checkbox();
 echo $form->field($generator, 'generateQuery')->checkbox();
 echo $form->field($generator, 'queryNs');


### PR DESCRIPTION
Without this change it is not possible to submit Model generation forms and "Generate Relations is invalid" error shows up.